### PR TITLE
Update gem versions, locking to omniauth-oauth2 1.3.1.

### DIFF
--- a/lib/omniauth-teamsnap/version.rb
+++ b/lib/omniauth-teamsnap/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Teamsnap
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end

--- a/omniauth-teamsnap.gemspec
+++ b/omniauth-teamsnap.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "omniauth", "~> 1.2"
-  spec.add_dependency "omniauth-oauth2", "~> 1.2"
+  spec.add_dependency "omniauth-oauth2", "~> 1.3.1"
   spec.add_dependency "faraday", "~> 0.9"
   spec.add_dependency "conglomerate", "~> 0.15"
   spec.add_development_dependency "rspec", "~> 2.7"


### PR DESCRIPTION
omniauth-oauth2 1.4.0 has a bug that will break apps using this gem.

https://github.com/intridea/omniauth-oauth2/issues/81