### PR TITLE
Fix Conglomerate error by removing it as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,21 @@ TeamSnap API v3 lets you set scopes to provide granular access to different type
       provider :teamsnap, ENV['TEAMSNAP_KEY'], ENV['TEAMSNAP_SECRET'], scope: "read write"
     end
 
+## Authentication Hash
+An example auth hash available in `request.env['omniauth.auth']`:
+
+```
+{
+  :provider => "teamsnap",
+  :uid => "123456",
+  :info => {
+    :email => "player@example.com",
+    :first_name => "John",
+    :last_name => "Player",
+  },
+  :credentials => {
+    :token => "a1b2c3d4...", # The OAuth 2.0 access token
+  },
+  :extra = {}
+}
+```

--- a/lib/omniauth-teamsnap/version.rb
+++ b/lib/omniauth-teamsnap/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Teamsnap
-    VERSION = "1.0.1"
+    VERSION = "1.1.0"
   end
 end

--- a/lib/omniauth/strategies/teamsnap.rb
+++ b/lib/omniauth/strategies/teamsnap.rb
@@ -12,13 +12,13 @@ module OmniAuth
         :token_method => :post
       }
 
-      uid { raw_info.find { |d| d.name == "id"}.value }
+      uid { parse_datum("id") }
 
       info do
         {
-          :email => raw_info.find { |d| d.name == "email"}.value,
-          :first_name => raw_info.find { |d| d.name == "first_name"}.value,
-          :last_name => raw_info.find { |d| d.name == "last_name"}.value
+          :email => parse_datum("email"),
+          :first_name => parse_datum("first_name"),
+          :last_name => parse_datum("last_name")
         }
       end
 
@@ -32,12 +32,16 @@ module OmniAuth
           req.url "https://api.teamsnap.com/v3/me"
           req.headers["Authorization"] = "Bearer #{access_token.token}"
         end
-        deserializer = Conglomerate::TreeDeserializer.new(JSON.parse(response.body))
-        collection_json = deserializer.deserialize
+        collection_json = JSON.parse(response.body)
 
-        @raw_info = collection_json.items.first.data
+        @raw_info = collection_json["collection"]["items"].first.fetch("data")
       end
 
+      private
+
+      def parse_datum(property)
+        raw_info.find { |d| d["name"] == property }.fetch("value")
+      end
     end
   end
 end

--- a/omniauth-teamsnap.gemspec
+++ b/omniauth-teamsnap.gemspec
@@ -19,8 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "omniauth", "~> 1.2"
   spec.add_dependency "omniauth-oauth2", "~> 1.3.1"
-  spec.add_dependency "faraday", "~> 0.9"
-  spec.add_dependency "conglomerate", "~> 0.15"
+  spec.add_dependency "faraday", "~> 0.9.2"
   spec.add_development_dependency "rspec", "~> 2.7"
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
This gem was breaking with conglomerate 0.16.0 which was being installed due to the `~0.15` version specification. Since there is only one request to parse, let's just do it without conglomerate?